### PR TITLE
Build advanced linked-tree navigation and discovery UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ npm install
 npm run dev
 ```
 
+Then open **http://localhost:5188/** (Vite is pinned to port **5188** with `strictPort` so you do not accidentally hit another project on the default **5173**). Local dev uses base `/`; production builds still use `/linkx/` for GitHub Pages.
+
 ## Tests
 
 ```bash

--- a/docs/linked-tree-navigation-workflow.md
+++ b/docs/linked-tree-navigation-workflow.md
@@ -1,0 +1,187 @@
+# Keyboard-Driven Linked-Tree Navigation (Power-User Workflow)
+
+This document defines a keyboard-first navigation model for a **linked tree** (hierarchical nodes that may also cross-link to related nodes), designed for LinkX-style interfaces where users rapidly traverse, open, and inspect nodes without leaving the keyboard.
+
+## Goals
+
+- Keep hands on keyboard for the full browse → inspect → open loop.
+- Support both strict parent/child traversal and cross-link jumping.
+- Preserve accessibility semantics (`aria-activedescendant`, roving focus, visible focus).
+- Integrate cleanly with existing `LinkXPage` and `Terminal` command patterns.
+
+## Interaction model
+
+### Concepts
+
+- **Active node**: currently selected tree node.
+- **Expanded state**: whether a branch node's children are visible.
+- **Peek mode**: temporary overlay/details for active node.
+- **Link ring**: ordered set of cross-links for the active node.
+- **Quick open buffer**: incremental fuzzy query for node IDs/titles.
+
+### Navigation principles
+
+1. **Arrow keys stay structural**
+   - Up/Down walk visible siblings in reading order.
+   - Left collapses or moves to parent.
+   - Right expands or moves to first child.
+2. **Cross-links are explicit**
+   - `[` / `]` cycle related/cross-linked nodes.
+3. **Actions are mnemonic**
+   - `o` open, `p` peek, `f` focus/search, `?` help.
+4. **Mode-less by default**
+   - Most commands are single-key actions.
+   - `Ctrl/Cmd+K` enters quick-open mode only when needed.
+
+## Shortcut map
+
+| Key | Scope | Action |
+| --- | --- | --- |
+| `↑` / `k` | Tree focused | Move to previous visible node |
+| `↓` / `j` | Tree focused | Move to next visible node |
+| `←` / `h` | Tree focused | Collapse current branch; if already collapsed, move to parent |
+| `→` / `l` | Tree focused | Expand current branch; if already expanded, move to first child |
+| `Home` | Tree focused | Jump to first visible node |
+| `End` | Tree focused | Jump to last visible node |
+| `PageUp` / `PageDown` | Tree focused | Jump by viewport chunk |
+| `Enter` | Tree focused | Open active node primary link (new tab for external) |
+| `o` | Tree focused | Open active node in current context (router push / modal) |
+| `Shift+Enter` | Tree focused | Open active node in background/new tab |
+| `Space` | Tree focused | Toggle expand/collapse on active node |
+| `a` | Tree focused | Expand all descendants of active node |
+| `A` (`Shift+a`) | Tree focused | Collapse all descendants of active node |
+| `[` / `]` | Tree focused | Cycle previous/next related cross-link |
+| `g g` | Tree focused | Jump to tree root |
+| `g n` | Tree focused | Jump to next unread/new node (if metadata exists) |
+| `p` | Tree focused | Toggle peek panel for active node |
+| `Ctrl/Cmd+K` | Global | Open quick-open palette (search node by title/id/tag) |
+| `/` | Tree focused | Focus in-tree filter input |
+| `Esc` | Global | Close peek/palette; clear transient mode; preserve active node |
+| `?` | Global | Show shortcut overlay |
+
+## Implementation hooks (drop-in architecture)
+
+## 1) Data contract for tree nodes
+
+```ts
+type TreeNode = {
+  id: string;
+  title: string;
+  href?: string;
+  children?: string[]; // child node IDs
+  parentId?: string | null;
+  relatedIds?: string[]; // cross-links
+  meta?: {
+    unread?: boolean;
+    tags?: string[];
+  };
+};
+```
+
+Store nodes in an ID map for O(1) lookups and a derived `visibleNodeIds` array.
+
+## 2) Keyboard controller hook
+
+Add a dedicated hook:
+
+- **File:** `src/hooks/useLinkedTreeNavigation.js`
+- **Responsibility:** parse key chords and emit semantic actions.
+
+Suggested API:
+
+```ts
+const {
+  activeId,
+  visibleNodeIds,
+  expandedIds,
+  quickOpen,
+  keymap,
+  onTreeKeyDown,
+  setActiveId,
+  toggleExpanded,
+  openActive,
+} = useLinkedTreeNavigation({
+  nodesById,
+  rootIds,
+  initialActiveId,
+  onOpen,
+  onPeek,
+  onHelp,
+});
+```
+
+## 3) Keymap registry
+
+Centralize shortcuts in a registry object so docs/tests/UI stay in sync:
+
+```ts
+const LINKED_TREE_SHORTCUTS = [
+  { key: "ArrowUp|k", action: "movePrev" },
+  { key: "ArrowDown|j", action: "moveNext" },
+  // ...
+];
+```
+
+Benefits:
+
+- renderable for `?` overlay,
+- testable without DOM,
+- future remapping support.
+
+## 4) UI wiring points in current codebase
+
+Primary integration target is `src/components/LinkXPage.jsx`:
+
+- replace link-list-only up/down logic (`onLinkKeyDown`) with tree-aware handler,
+- keep refs (`linkRefs`) for roving tab stop or switch to `aria-activedescendant`,
+- preserve existing `Enter` behavior and analytics (`trackOutbound`),
+- reserve `Esc` priority for terminal/dialog close, then tree mode cleanup.
+
+Optional terminal integration (`src/components/Terminal/commands.js`):
+
+- add `tree` command namespace:
+  - `tree keys` → print shortcut map,
+  - `tree focus <id>` → focus node by ID,
+  - `tree open <id>` → open node programmatically.
+
+## 5) Accessibility hooks
+
+- Tree container: `role="tree"`, `aria-label="Linked tree navigation"`.
+- Nodes: `role="treeitem"` with `aria-level`, `aria-expanded` (branches), `aria-current` (active).
+- Child groups: `role="group"`.
+- Use **roving tabindex** (single `tabIndex=0` on active, `-1` elsewhere), or `aria-activedescendant`.
+- Announce active-node changes in a polite live region for screen-reader context.
+
+## 6) Telemetry hooks
+
+Track power-user behavior without PII:
+
+- `tree_nav_move` (direction + source key),
+- `tree_nav_open` (node id + method keyboard/mouse),
+- `tree_nav_jump` (root/unread/quick-open),
+- `tree_nav_help_open`.
+
+Implementation: re-use existing analytics style from `src/lib/analytics.js`.
+
+## Test plan
+
+1. **Unit (hook-level)**
+   - key parsing (`g g`, `g n`, `Ctrl/Cmd+K`),
+   - traversal boundaries,
+   - expand/collapse semantics,
+   - related link cycling.
+2. **Component**
+   - `role="tree"` semantics and correct aria attributes.
+   - active node remains stable across expand/collapse.
+3. **E2E (Playwright)**
+   - keyboard-only path from page load to opening a deep child link.
+   - shortcut overlay toggling with `?`.
+   - `Esc` precedence (peek/palette close before terminal close unless terminal is active).
+
+## Rollout strategy
+
+1. Ship keymap registry + read-only shortcut overlay (`?`).
+2. Introduce tree controller hook behind feature flag.
+3. Migrate existing flat links into tree adapter (`links.json` -> tree model).
+4. Add terminal `tree` commands for discoverability/debugging.
+5. Remove legacy `onLinkKeyDown` once parity is validated.

--- a/src/LinkX.test.jsx
+++ b/src/LinkX.test.jsx
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, test } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import LinkXPage from "./components/LinkXPage";
 
 beforeAll(() => {
@@ -39,5 +40,22 @@ describe("LinkX smoke test", () => {
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", "noopener noreferrer");
     }
+  });
+
+  test("supports grouped linked-tree search and tag filtering", async () => {
+    const user = userEvent.setup();
+    render(<LinkXPage />);
+
+    const treeNav = screen.getByRole("navigation", { name: /external links/i });
+    expect(within(treeNav).getByText("Work")).toBeInTheDocument();
+    expect(within(treeNav).getByText("Build")).toBeInTheDocument();
+    expect(within(treeNav).getByText("Social")).toBeInTheDocument();
+
+    const searchInput = screen.getByRole("textbox", { name: /search links/i });
+    await user.type(searchInput, "tag:build");
+
+    expect(screen.getByRole("link", { name: /portfolio/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /github/i })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /instagram/i })).not.toBeInTheDocument();
   });
 });

--- a/src/components/LinkXPage.jsx
+++ b/src/components/LinkXPage.jsx
@@ -1,19 +1,36 @@
-import { useRef, useEffect, useState, useCallback } from "react";
+import { useRef, useEffect, useState, useCallback, useMemo, lazy, Suspense } from "react";
 import ProfilePhoto from "../assets/imgs/boyd-striped.jpeg";
-import LINKS from "../data/links";
+import LINKS, { filterLinks, groupLinks } from "../data/links";
 import useParticleField from "../hooks/useParticleField";
 import useShaderField from "../hooks/useShaderField";
 import useKonamiCode from "./Terminal/useKonamiCode";
-import Terminal from "./Terminal/Terminal";
-import NowSection from "./NowSection";
 import { trackOutbound } from "../lib/analytics";
+
+const Terminal = lazy(() => import("./Terminal/Terminal"));
+const NowSection = lazy(() => import("./NowSection"));
+
+function highlightText(text, queryTokens) {
+  if (!queryTokens.length) return text;
+  const lowered = text.toLowerCase();
+  const firstToken = queryTokens.find((token) => lowered.includes(token));
+  if (!firstToken) return text;
+  const start = lowered.indexOf(firstToken);
+  const end = start + firstToken.length;
+  return (
+    <>
+      {text.slice(0, start)}
+      <mark className="lx-match">{text.slice(start, end)}</mark>
+      {text.slice(end)}
+    </>
+  );
+}
 
 function LinkXPage() {
   const particleRef = useRef(null);
   const shaderRef = useRef(null);
-  const linkRefs = useRef([]);
   const [revealed, setRevealed] = useState(false);
   const [terminalOpen, setTerminalOpen] = useState(false);
+  const [search, setSearch] = useState("");
 
   useEffect(() => {
     const timer = setTimeout(() => setRevealed(true), 100);
@@ -29,13 +46,16 @@ function LinkXPage() {
   const closeTerminal = useCallback(() => setTerminalOpen(false), []);
   useKonamiCode(openTerminal);
 
-  const onLinkKeyDown = useCallback((e, index) => {
-    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
-    e.preventDefault();
-    const delta = e.key === "ArrowDown" ? 1 : -1;
-    const next = (index + delta + LINKS.length) % LINKS.length;
-    linkRefs.current[next]?.focus();
-  }, []);
+  const filteredLinks = useMemo(() => filterLinks(search), [search]);
+  const groupedLinks = useMemo(() => groupLinks(filteredLinks), [filteredLinks]);
+  const queryTokens = useMemo(
+    () => search.trim().toLowerCase().split(/\s+/).filter((token) => token && !token.startsWith("tag:")),
+    [search]
+  );
+  const relatedLookup = useMemo(
+    () => Object.fromEntries(LINKS.map((link) => [link.id, link])),
+    []
+  );
 
   return (
     <div className={`lx ${revealed ? "lx--revealed" : ""}`}>
@@ -73,43 +93,72 @@ function LinkXPage() {
           </div>
         </div>
 
-        <nav className="lx-links" aria-label="External links">
-          {LINKS.map((link, i) => {
-            const Icon = link.icon;
-            return (
-              <a
-                key={link.id}
-                ref={(el) => {
-                  linkRefs.current[i] = el;
-                }}
-                href={link.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`lx-link ${link.toneClass}`}
-                style={{ "--i": i }}
-                onClick={() => trackOutbound(link.id, link.href)}
-                onKeyDown={(e) => onLinkKeyDown(e, i)}
-                data-link-id={link.id}
-              >
-                <span className="lx-link-glow" aria-hidden="true" />
-                <span className="lx-link-icon" aria-hidden="true">
-                  <Icon />
-                </span>
-                <span className="lx-link-body">
-                  <span className="lx-link-name">{link.name}</span>
-                  <span className="lx-link-sub">{link.tagline}</span>
-                </span>
-                <span className="lx-link-go" aria-hidden="true">
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M7 17L17 7M17 7H7M17 7v10" />
-                  </svg>
-                </span>
-              </a>
-            );
-          })}
+        <section className="lx-tree-controls" aria-label="Search links">
+          <input
+            type="text"
+            className="lx-tree-search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search links or use tag:build"
+            aria-label="Search links"
+          />
+          <div className="lx-tree-meta">
+            <span>{filteredLinks.length} matches</span>
+            <span>Try: tag:social, tag:build</span>
+          </div>
+        </section>
+
+        <nav className="lx-tree" aria-label="External links">
+          {groupedLinks.map((group, groupIndex) => (
+            <section key={group.id} className="lx-branch" style={{ "--g": groupIndex }} aria-label={group.label}>
+              <h2 className="lx-branch-title">{group.label}</h2>
+              <ul className="lx-branch-list">
+                {group.links.map((link, i) => {
+                  const Icon = link.icon;
+                  return (
+                    <li key={link.id} className={`lx-node ${link.toneClass}`} style={{ "--i": i }} data-link-id={link.id}>
+                      <a
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={`lx-link ${link.toneClass}`}
+                        onClick={() => trackOutbound(link.id, link.href)}
+                      >
+                        <span className="lx-link-glow" aria-hidden="true" />
+                        <span className="lx-link-icon" aria-hidden="true">
+                          <Icon />
+                        </span>
+                        <span className="lx-link-body">
+                          <span className="lx-link-name">{highlightText(link.name, queryTokens)}</span>
+                          <span className="lx-link-sub">{highlightText(link.tagline, queryTokens)}</span>
+                          <span className="lx-link-tags" aria-hidden="true">{(link.tags || []).slice(0, 3).join(" · ")}</span>
+                        </span>
+                        <span className="lx-link-go" aria-hidden="true">
+                          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M7 17L17 7M17 7H7M17 7v10" />
+                          </svg>
+                        </span>
+                      </a>
+                      <div className="lx-link-related" aria-hidden="true">
+                        {(link.related || []).map((rel) => {
+                          const related = relatedLookup[rel];
+                          if (!related) return null;
+                          return (
+                            <span key={rel} className="lx-related-chip">{related.name}</span>
+                          );
+                        })}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          ))}
         </nav>
 
-        <NowSection />
+        <Suspense fallback={null}>
+          <NowSection />
+        </Suspense>
 
         <footer className="lx-foot">
           <button
@@ -136,7 +185,11 @@ function LinkXPage() {
         </footer>
       </main>
 
-      {terminalOpen && <Terminal onClose={closeTerminal} />}
+      {terminalOpen && (
+        <Suspense fallback={null}>
+          <Terminal onClose={closeTerminal} />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/src/components/Terminal/commands.js
+++ b/src/components/Terminal/commands.js
@@ -67,6 +67,35 @@ export const COMMANDS = {
   ],
 
   links: () => LINKS.map((l) => `  ${l.name.padEnd(10)} ${l.href}`),
+  find: (args) => {
+    const query = args.join(" ").trim().toLowerCase();
+    if (!query) return ["usage: find <query>"];
+    const matches = LINKS.filter((link) =>
+      [link.name, link.tagline, ...(link.tags || []), ...(link.aliases || []), link.id]
+        .join(" ")
+        .toLowerCase()
+        .includes(query)
+    );
+    if (!matches.length) return [`no matches for "${query}"`];
+    return [
+      `matches (${matches.length}):`,
+      ...matches.map((link) => `  ${link.name.padEnd(10)} ${link.href}`),
+    ];
+  },
+  related: (args) => {
+    const id = args[0]?.toLowerCase();
+    if (!id) return ["usage: related <link-id>"];
+    const link = LINKS.find((item) => item.id.toLowerCase() === id);
+    if (!link) return [`unknown link id: ${id}`];
+    const related = (link.related || [])
+      .map((relId) => LINKS.find((item) => item.id === relId))
+      .filter(Boolean);
+    if (!related.length) return [`${link.name} has no related links configured`];
+    return [
+      `${link.name} related links:`,
+      ...related.map((item) => `  ${item.name.padEnd(10)} ${item.href}`),
+    ];
+  },
 
   theme: () => {
     if (typeof window === "undefined" || !window.matchMedia) {

--- a/src/components/Terminal/commands.test.js
+++ b/src/components/Terminal/commands.test.js
@@ -53,4 +53,15 @@ describe("terminal command parser", () => {
     const out = runCommand("projects").join(" ");
     expect(out).toContain("https://github.com/coleyrockin/linkx");
   });
+
+  test("find command returns ranked matches", () => {
+    const out = runCommand("find git");
+    expect(out[0]).toMatch(/^matches \(\d+\):$/);
+    expect(out.join(" ")).toMatch(/github/i);
+  });
+
+  test("related command shows connected nodes", () => {
+    const out = runCommand("related github");
+    expect(out.join(" ")).toMatch(/Portfolio|LinkedIn|X/i);
+  });
 });

--- a/src/data/links.js
+++ b/src/data/links.js
@@ -12,4 +12,45 @@ const ICONS = {
 
 const LINKS = linksData.map((link) => ({ ...link, icon: ICONS[link.id] }));
 
+export const GROUP_ORDER = ["work", "build", "social"];
+export const GROUP_LABELS = {
+  work: "Work",
+  build: "Build",
+  social: "Social",
+};
+
+export function scoreLink(link, queryTokens) {
+  if (!queryTokens.length) return 1;
+  const corpus = [link.name, link.tagline, ...(link.tags || []), ...(link.aliases || []), link.id]
+    .join(" ")
+    .toLowerCase();
+  return queryTokens.reduce((score, token) => {
+    if (corpus.includes(token)) return score + (link.name.toLowerCase().includes(token) ? 3 : 1);
+    return score;
+  }, 0);
+}
+
+export function filterLinks(searchInput = "") {
+  const query = searchInput.trim().toLowerCase();
+  if (!query) return LINKS;
+  const tokens = query.split(/\s+/).filter(Boolean);
+  const tagTokens = tokens.filter((token) => token.startsWith("tag:")).map((token) => token.slice(4));
+  const textTokens = tokens.filter((token) => !token.startsWith("tag:"));
+
+  return LINKS
+    .filter((link) => tagTokens.every((tag) => (link.tags || []).includes(tag)))
+    .map((link) => ({ link, score: scoreLink(link, textTokens) }))
+    .filter((item) => (textTokens.length ? item.score > 0 : true))
+    .sort((a, b) => b.score - a.score || a.link.name.localeCompare(b.link.name))
+    .map((item) => item.link);
+}
+
+export function groupLinks(links) {
+  return GROUP_ORDER.map((group) => ({
+    id: group,
+    label: GROUP_LABELS[group],
+    links: links.filter((link) => link.group === group),
+  })).filter((group) => group.links.length > 0);
+}
+
 export default LINKS;

--- a/src/data/links.json
+++ b/src/data/links.json
@@ -4,34 +4,54 @@
     "name": "Instagram",
     "href": "https://www.instagram.com/coleyrockin/",
     "tagline": "Behind the scenes",
-    "toneClass": "tone-instagram"
+    "toneClass": "tone-instagram",
+    "group": "social",
+    "tags": ["social", "visual", "behind-the-scenes"],
+    "related": ["linkedin", "x"],
+    "aliases": ["ig", "reels", "stories"]
   },
   {
     "id": "linkedin",
     "name": "LinkedIn",
     "href": "https://www.linkedin.com/in/boydcroberts/",
     "tagline": "Professional world",
-    "toneClass": "tone-linkedin"
+    "toneClass": "tone-linkedin",
+    "group": "work",
+    "tags": ["work", "career", "network"],
+    "related": ["portfolio", "github"],
+    "aliases": ["resume", "professional", "cv"]
   },
   {
     "id": "portfolio",
     "name": "Portfolio",
     "href": "https://coleyrockin.github.io/react-portfolio/",
     "tagline": "Projects and builds",
-    "toneClass": "tone-portfolio"
+    "toneClass": "tone-portfolio",
+    "group": "build",
+    "tags": ["build", "projects", "frontend"],
+    "related": ["github", "linkedin"],
+    "aliases": ["showcase", "case studies", "work samples"]
   },
   {
     "id": "github",
     "name": "GitHub",
     "href": "https://github.com/coleyrockin",
     "tagline": "Code and open source",
-    "toneClass": "tone-github"
+    "toneClass": "tone-github",
+    "group": "build",
+    "tags": ["build", "code", "opensource"],
+    "related": ["portfolio", "linkedin", "x"],
+    "aliases": ["repos", "oss", "source"]
   },
   {
     "id": "x",
     "name": "X",
     "href": "https://x.com/coleyrockin",
     "tagline": "Thoughts and threads",
-    "toneClass": "tone-x"
+    "toneClass": "tone-x",
+    "group": "social",
+    "tags": ["social", "thoughts", "updates"],
+    "related": ["instagram", "github"],
+    "aliases": ["twitter", "posts", "threads"]
   }
 ]

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -277,6 +277,69 @@ body {
   width: 100%;
 }
 
+.lx-tree-controls {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.lx-tree-search {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass);
+  color: var(--ink);
+  font: inherit;
+  padding: 0.65rem 0.8rem;
+}
+
+.lx-tree-search:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.lx-tree-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  color: var(--ink-dim);
+  gap: 0.5rem;
+}
+
+.lx-tree {
+  display: grid;
+  gap: 0.9rem;
+  width: 100%;
+}
+
+.lx-branch {
+  border: 1px solid var(--glass-border);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--glass) 88%, transparent);
+  padding: 0.65rem 0.7rem 0.7rem;
+}
+
+.lx-branch-title {
+  font: 700 0.68rem/1 "Space Grotesk", system-ui, sans-serif;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  margin: 0 0 0.45rem 0.2rem;
+}
+
+.lx-branch-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.lx-node {
+  position: relative;
+}
+
 .lx-link {
   --tone-rgb: 255, 255, 255;
   position: relative;
@@ -409,6 +472,12 @@ body {
   color: var(--ink-dim);
 }
 
+.lx-link-tags {
+  font-size: 0.68rem;
+  color: var(--ink-dim);
+  opacity: 0.75;
+}
+
 /* Arrow */
 .lx-link-go {
   display: grid;
@@ -422,6 +491,29 @@ body {
 .lx-link:hover .lx-link-go {
   opacity: 1;
   transform: translate(0, 0);
+}
+
+.lx-link-related {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0.38rem 0.1rem 0.1rem 3.95rem;
+}
+
+.lx-related-chip {
+  border: 1px solid var(--glass-border);
+  border-radius: 999px;
+  padding: 0.14rem 0.48rem;
+  font-size: 0.65rem;
+  color: var(--ink-dim);
+  background: color-mix(in srgb, var(--glass) 75%, transparent);
+}
+
+.lx-match {
+  background: color-mix(in srgb, var(--focus) 40%, transparent);
+  color: inherit;
+  border-radius: 4px;
+  padding: 0 2px;
 }
 
 /* ── Tone colors ────────────────────────────────────── */

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,28 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
-  base: "/linkx/",
-  plugins: [react()],
+// GitHub Pages serves this repo at /linkx/. Local dev uses "/" so http://localhost:5188/
+// is unambiguous (port 5173 is often another Vite project).
+const pagesBase = "/linkx/";
+
+export default defineConfig(({ command }) => ({
+  base: command === "serve" ? "/" : pagesBase,
+  plugins: [
+    react(),
+    {
+      name: "linkx-dev-html-asset-paths",
+      transformIndexHtml(html, ctx) {
+        if (!ctx.server) return html;
+        // index.html hardcodes /linkx/ for production OG URLs and public assets;
+        // rewrite only same-origin asset links for dev with base "/".
+        return html.replaceAll('href="/linkx/', 'href="/');
+      },
+    },
+  ],
+  server: {
+    port: 5188,
+    strictPort: true,
+  },
   build: {
     outDir: "build",
     sourcemap: false,
@@ -14,4 +33,4 @@ export default defineConfig({
     globals: true,
     exclude: ["node_modules", "tests/e2e/**", "build"],
   },
-});
+}));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- upgrade the link stack into a grouped linked-tree presentation (Work, Build, Social)
- extend link data model with relationship metadata (`group`, `tags`, `related`, `aliases`) and add search/group helpers
- add in-page linked-tree search with fuzzy-ish ranking, `tag:` filtering, and inline highlighted matches
- render related-link chips under each node for graph context
- lazy-load `NowSection` and `Terminal` to improve initial bundle loading
- add graph-aware terminal commands: `find <query>` and `related <id>`

## Accessibility and UX
- replace the previous arrow-key interception model with native list semantics (`nav > section > ul > li > a`)
- keep external-link security attributes and improve scanability with branch titles, tags, and relation chips

## Testing
- update smoke tests to assert grouped tree rendering and search behavior
- add terminal command tests for `find` and `related`
- pass `npm test`
- pass `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27a980c5-c6a2-4d5a-9208-0282986d49f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27a980c5-c6a2-4d5a-9208-0282986d49f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

