### PR TITLE
Fix GitHub Pages stale UI: service worker + deploy stamp

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -44,6 +44,8 @@ jobs:
         run: npm ci
 
       - name: Build
+        env:
+          GITHUB_SHA: ${{ github.sha }}
         run: npm run build
 
       - name: Upload Pages artifact

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ export default [
       globals: {
         ...globals.browser,
         ...globals.node,
+        __LINKX_BUILD__: "readonly",
       },
     },
     plugins: {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,25 +1,18 @@
-// LinkX service worker — cache-first for the shell, network-first for everything else.
-// Bumping CACHE keeps upgrades honest (old entries auto-expire on activation).
-const CACHE = "linkx-v1";
-const SHELL = [
-  "/linkx/",
-  "/linkx/index.html",
-  "/linkx/favicon.ico",
-  "/linkx/apple-touch-icon.png",
-  "/linkx/site.webmanifest",
-];
+// LinkX service worker — navigations network-first; hashed assets network-first so updates always land.
+// Bump CACHE_NAME when changing caching rules.
+const CACHE_NAME = "linkx-v3";
 
 self.addEventListener("install", (event) => {
-  event.waitUntil(
-    caches.open(CACHE).then((cache) => cache.addAll(SHELL)).then(() => self.skipWaiting())
-  );
+  self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
     caches
       .keys()
-      .then((keys) => Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))))
+      .then((keys) =>
+        Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+      )
       .then(() => self.clients.claim())
   );
 });
@@ -31,33 +24,56 @@ self.addEventListener("fetch", (event) => {
   const url = new URL(req.url);
   if (url.origin !== self.location.origin) return;
 
-  // Navigation: network-first, fall back to cached shell.
+  const path = url.pathname;
+  const isHashedAsset =
+    path.includes("/assets/") && /\.(js|css|woff2?|png|jpe?g|svg|webp)$/i.test(path);
+
+  // Hashed Vite bundles: always try network first (cache busted by filename).
+  if (isHashedAsset) {
+    event.respondWith(
+      fetch(req)
+        .then((res) => {
+          if (res.ok) {
+            const copy = res.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(req, copy));
+          }
+          return res;
+        })
+        .catch(() => caches.match(req))
+    );
+    return;
+  }
+
+  // HTML navigations: network first, then cached shell.
   if (req.mode === "navigate") {
     event.respondWith(
       fetch(req)
         .then((res) => {
           const copy = res.clone();
-          caches.open(CACHE).then((cache) => cache.put(req, copy));
+          if (res.ok) {
+            caches.open(CACHE_NAME).then((cache) => cache.put(req, copy));
+          }
           return res;
         })
-        .catch(() => caches.match("/linkx/index.html"))
+        .catch(() => caches.match("/linkx/index.html").then((r) => r || caches.match("/linkx/")))
     );
     return;
   }
 
-  // Static assets: stale-while-revalidate.
+  // Other same-origin GETs: stale-while-revalidate (network updates cache in background).
   event.respondWith(
     caches.match(req).then((cached) => {
-      const network = fetch(req)
+      const networkFetch = fetch(req)
         .then((res) => {
           if (res.ok) {
             const copy = res.clone();
-            caches.open(CACHE).then((cache) => cache.put(req, copy));
+            caches.open(CACHE_NAME).then((cache) => cache.put(req, copy));
           }
           return res;
         })
-        .catch(() => cached);
-      return cached || network;
+        .catch(() => null);
+
+      return networkFetch.then((networkRes) => networkRes || cached);
     })
   );
 });

--- a/src/LinkX.test.jsx
+++ b/src/LinkX.test.jsx
@@ -45,5 +45,9 @@ describe("LinkX smoke test", () => {
     expect(screen.getByRole("article", { name: /profile and links/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /open terminal/i })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: /^now$/i })).toBeInTheDocument();
+    expect(
+      screen.getByTitle(/deploy id from github actions/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText("local")).toBeInTheDocument();
   });
 });

--- a/src/components/LinkXPage.jsx
+++ b/src/components/LinkXPage.jsx
@@ -9,15 +9,25 @@ import { trackOutbound } from "../lib/analytics";
 const Terminal = lazy(() => import("./Terminal/Terminal"));
 const NowSection = lazy(() => import("./NowSection"));
 
+// Injected at build time (first 7 chars of GITHUB_SHA on CI, else "local").
+const BUILD_ID = __LINKX_BUILD__;
+
 function LinkXPage() {
   const particleRef = useRef(null);
   const shaderRef = useRef(null);
   const [revealed, setRevealed] = useState(false);
   const [terminalOpen, setTerminalOpen] = useState(false);
+  const [updateReady, setUpdateReady] = useState(false);
 
   useEffect(() => {
     const timer = requestAnimationFrame(() => setRevealed(true));
     return () => cancelAnimationFrame(timer);
+  }, []);
+
+  useEffect(() => {
+    const onSwUpdated = () => setUpdateReady(true);
+    window.addEventListener("linkx-sw-updated", onSwUpdated);
+    return () => window.removeEventListener("linkx-sw-updated", onSwUpdated);
   }, []);
 
   const shaderSupported = useShaderField(shaderRef);
@@ -39,6 +49,15 @@ function LinkXPage() {
       <div className="lx-aurora" aria-hidden="true" data-shader={shaderSupported === true ? "true" : "false"} />
       <div className="lx-grain" aria-hidden="true" />
       <div className="lx-vignette" aria-hidden="true" />
+
+      {updateReady && (
+        <div className="lx-update-banner" role="status">
+          <span>New version available.</span>
+          <button type="button" className="lx-update-reload" onClick={() => window.location.reload()}>
+            Reload
+          </button>
+        </div>
+      )}
 
       <main id="main" className="lx-main">
         <article className="lx-panel" aria-label="Profile and links">
@@ -116,6 +135,12 @@ function LinkXPage() {
                 Konami · or tap
               </span>
             </button>
+            <p
+              className="lx-build"
+              title="Deploy id from GitHub Actions (production) or “local” in dev. If this looks old, hard-refresh or tap Reload when an update banner appears."
+            >
+              deploy <code>{BUILD_ID}</code>
+            </p>
           </footer>
         </article>
       </main>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -17,8 +17,23 @@ root.render(
 // and serves its last-known version when the network drops.
 if ("serviceWorker" in navigator && import.meta.env.PROD) {
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch(() => {
-      /* intentional: install is best-effort */
-    });
+    navigator.serviceWorker
+      .register(`${import.meta.env.BASE_URL}sw.js`)
+      .then((reg) => {
+        reg.update();
+        reg.addEventListener("updatefound", () => {
+          const next = reg.installing;
+          if (next) {
+            next.addEventListener("statechange", () => {
+              if (next.state === "installed" && navigator.serviceWorker.controller) {
+                window.dispatchEvent(new CustomEvent("linkx-sw-updated"));
+              }
+            });
+          }
+        });
+      })
+      .catch(() => {
+        /* intentional: install is best-effort */
+      });
   });
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,5 +1,40 @@
 /* LinkX — signal stack (high-contrast, electric backdrop) */
 
+.lx-update-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.55rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--bg);
+  background: var(--accent);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+}
+
+.lx-update-reload {
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--row-radius);
+  border: 2px solid rgba(0, 0, 0, 0.35);
+  background: var(--bg);
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 0.75rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.lx-update-reload:focus-visible {
+  outline: 2px solid var(--bg);
+  outline-offset: 2px;
+}
+
 :root {
   --bg: #030306;
   --bg-elevated: #0b0c12;
@@ -646,6 +681,22 @@ body {
 .lx-terminal-trigger:hover .lx-terminal-trigger-hint,
 .lx-terminal-trigger:focus-visible .lx-terminal-trigger-hint {
   opacity: 1;
+}
+
+.lx-build {
+  margin-top: 0.65rem;
+  text-align: center;
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  opacity: 0.55;
+}
+
+.lx-build code {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--accent) 55%, var(--text-muted));
 }
 
 /* Skip link */

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,12 @@ const pagesBase = "/linkx/";
 
 export default defineConfig(({ command }) => ({
   base: command === "serve" ? "/" : pagesBase,
+  define: {
+    // Shown in UI so you can confirm GitHub Pages served the latest deploy (see public/sw.js).
+    __LINKX_BUILD__: JSON.stringify(
+      process.env.GITHUB_SHA?.slice(0, 7) || "local"
+    ),
+  },
   plugins: [
     react(),
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Users reported the live site "looks the same" after redesigns. The previous service worker used **stale-while-revalidate** for hashed JS/CSS bundles, which could keep old `index-*.js` in cache and make updates invisible.

## Changes

- **Service worker (`public/sw.js`)**: Network-first for `/assets/*.{js,css,...}` so new hashed bundles load immediately; bumped cache name to `linkx-v3` to drop old caches.
- **SW lifecycle (`src/main.jsx`)**: Call `reg.update()` on load; show a **Reload** banner when a new worker is installed.
- **Deploy verification**: `__LINKX_BUILD__` from `GITHUB_SHA` in CI (first 7 chars); footer line **deploy `abc1234`** (or `local` in dev).
- **Workflow**: Pass `GITHUB_SHA` into the build step for the define.

## How to verify

- After merge and Pages deploy, open the live site and scroll to the footer: **deploy** should show a short git hash matching the latest commit on `main`.
- If an old bundle was stuck, you may see a cyan **New version available** bar once; tap **Reload**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27a980c5-c6a2-4d5a-9208-0282986d49f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27a980c5-c6a2-4d5a-9208-0282986d49f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

